### PR TITLE
fix(author-block): remove empty avatar div

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -199,3 +199,24 @@ add_filter( 'default_wp_template_part_areas', __NAMESPACE__ . '\template_part_ar
  * Load WooCommerce specific functions.
  */
 require_once get_template_directory() . '/inc/woocommerce.php';
+
+/**
+ * Remove empty avatar div from the post author block.
+ *
+ * @since 1.1.0
+ * @param string $block_content The block content.
+ * @param array  $block         The parsed block data.
+ * @return string The modified block content.
+ */
+function remove_empty_post_author_avatar( $block_content, $block ) {
+	$empty_avatar_div = '<div class="wp-block-post-author__avatar"></div>';
+
+	// When avatars are disabled in Settings > Discussion, or otherwise miss an image,
+	// the core block renders an empty div. We remove it entirely to prevent layout gaps.
+	if ( strpos( $block_content, $empty_avatar_div ) !== false ) {
+		$block_content = str_replace( $empty_avatar_div, '', $block_content );
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block_core/post-author', __NAMESPACE__ . '\remove_empty_post_author_avatar', 10, 2 );


### PR DESCRIPTION
## Summary

Removes the empty avatar div rendered by the core `post-author` block.

Fixes #194

## Problem

When avatars are disabled (`Settings > Discussion`) or an author has no avatar, the `core/post-author` block outputs an empty `<div class="wp-block-post-author__avatar"></div>`. This empty div creates an unwanted gap due to assigned CSS margins (`margin-right: .8rem;`).

## Solution

A PHP filter was added to `render_block_core/post-author` to intercept the block's output and completely strip the empty avatar div during server-side rendering. This prevents the browser from applying the empty spacer styling.

## Changes

### `functions.php`

```php
function remove_empty_post_author_avatar( $block_content, $block ) {
	$empty_avatar_div = '<div class="wp-block-post-author__avatar"></div>';

	// When avatars are disabled in Settings > Discussion, or otherwise miss an image,
	// the core block renders an empty div. We remove it entirely to prevent layout gaps.
	if ( strpos( $block_content, $empty_avatar_div ) !== false ) {
		$block_content = str_replace( $empty_avatar_div, '', $block_content );
	}

	return $block_content;
}
add_filter( 'render_block_core/post-author', __NAMESPACE__ . '\remove_empty_post_author_avatar', 10, 2 );
```

**Why:** Using a PHP filter ensures the empty element is never output to the browser rather than just hiding it with CSS, which is a cleaner and more robust approach.

## Testing

**Test 1: Avatars Disabled / Missing**
- Steps: 
1) Go to Settings > Discussion and uncheck "Show Avatars". 
2) View a post utilizing the author block.
- Result: Works as expected. The author block renders cleanly without a left gap, and the source code shows no empty avatar div.

## Screenshot
<img width="1446" height="763" alt="3A50DDDB-869A-4F95-A5D9-390C82BFC60F" src="https://github.com/user-attachments/assets/a169f641-02ca-4a07-adf2-350e1b8d5d9f" />
