### PR TITLE
fix(styles): fix Firefox thick underline bug on navigation hover

### DIFF
--- a/assets/styles/core-navigation.css
+++ b/assets/styles/core-navigation.css
@@ -4,6 +4,7 @@
 .wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation__container .current-menu-item > a,
 .wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation__container .has-child button:hover {
 	text-decoration: underline;
+	text-decoration-thickness: 0.1rem;
 }
 
 /* Drop nav */


### PR DESCRIPTION
## Summary
 
This PR fixes the unusually thick underline rendered in Firefox when hovering over navigation items with submenus.
 
Fixes #193
 
## Problem
 
Firefox computes a thick underline for submenu toggles (`<button>` elements in `.has-child`) because it derives thickness from the `font: inherit` property defined in the global form reset.
 
## Solution
 
Added `text-decoration-thickness: 0.1rem` to the hover state of the navigation menu items. This explicitly overrides Firefox's calculated thickness and matches the fix already used for standard anchor (`<a>`) tags within the theme.
 
## Changes
 
### assets/styles/core-navigation.css
 
**Before:**
```css
.wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation__container .current-menu-item > a,
.wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation__container .has-child button:hover {
	text-decoration: underline;
}
```
 
**After:**
```css
.wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation__container .current-menu-item > a,
.wp-block-navigation__responsive-container:not(.is-menu-open) .wp-block-navigation__container .has-child button:hover {
	text-decoration: underline;
	text-decoration-thickness: 0.1rem;
}
```
 
**Why:** Defines an explicit underline thickness to prevent Firefox from using the font's incorrect built-in metrics, ensuring consistent appearance across browsers.
 
## Testing
 
**Test 1: Firefox Underline Thickness**
- Steps: 
1) Open site in Firefox 
2) Hover over a top-level nav item that has a sub-menu 
3) Check underline thickness
- Result: Works as expected, underline is normal thickness matching Chrome.

**Test 2: Chrome/Safari Regression Check**
- Steps: 1) View the same menu items in Chrome/Safari
- Result: Handled correctly, appearance remains unchanged.
 
## Build
 
[ollie-fix-193.zip](https://github.com/user-attachments/files/26281677/ollie-fix-193.zip) available for manual testing in the working directory (prior to commit).

Install: WP Admin → Themes → Add New → Upload Theme
 
## Screenshot
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/f72c85ac-2363-4476-beb6-54281e152f36" />
