### PR TITLE
Remove mobile cover min-height override

### DIFF
--- a/assets/styles/core-cover.css
+++ b/assets/styles/core-cover.css
@@ -22,9 +22,3 @@
 .is-style-rounded-cover img {
 	border-radius: 5px;
 }
-
-@media (max-width: 781px) {
-	.wp-block-cover:not(.has-aspect-ratio) {
-		min-height: 430px !important;
-	}
-}


### PR DESCRIPTION
Setting a minimum height at an arbitrary value with an important flag doesn't allow for user preference to be respected in terms of setting the min height of the cover block in the editor.

For example, if we have a cover block that is meant to take up 50vh on desktop, but should collapse down to just have its height set by the content plus the padding on mobile, then this prevents that.

If there must be a min-height set, it probably should be given only a tiny bit more specificity than this without going all-out and setitng the !important flag, such that the editor can still override it from a value set there.